### PR TITLE
Implement transparency and more efficient Occlusion calculations

### DIFF
--- a/crates/bones3_core/src/storage/data.rs
+++ b/crates/bones3_core/src/storage/data.rs
@@ -47,7 +47,7 @@ where
         let index = Region::CHUNK.point_to_index(local_pos & 15).unwrap();
         match &self.blocks {
             Some(arr) => arr[index],
-            None => T::default() 
+            None => T::default(),
         }
     }
 
@@ -64,7 +64,7 @@ where
                 let mut chunk = Box::new([T::default(); 4096]);
                 chunk[index] = data;
                 self.blocks = Some(chunk);
-            }
+            },
         }
     }
 }

--- a/crates/bones3_core/src/storage/data.rs
+++ b/crates/bones3_core/src/storage/data.rs
@@ -20,7 +20,7 @@ where
 {
     /// The block data array for this chunk.
     #[reflect(ignore)]
-    blocks: Box<[T; 4096]>,
+    blocks: Option<Box<[T; 4096]>>,
 }
 
 impl<T> Default for VoxelStorage<T>
@@ -29,7 +29,7 @@ where
 {
     fn default() -> Self {
         Self {
-            blocks: Box::new([T::default(); 4096]),
+            blocks: Some(Box::new([T::default(); 4096])),
         }
     }
 }
@@ -45,7 +45,10 @@ where
     /// back ground to the other side.
     pub fn get_block(&self, local_pos: IVec3) -> T {
         let index = Region::CHUNK.point_to_index(local_pos & 15).unwrap();
-        self.blocks[index]
+        match &self.blocks {
+            Some(arr) => arr[index],
+            None => T::default() 
+        }
     }
 
     /// Sets the block data at the local grid coordinates within this storage
@@ -55,6 +58,13 @@ where
     /// back ground to the other side.
     pub fn set_block(&mut self, local_pos: IVec3, data: T) {
         let index = Region::CHUNK.point_to_index(local_pos & 15).unwrap();
-        self.blocks[index] = data
+        match &mut self.blocks {
+            Some(arr) => arr[index] = data,
+            None => {
+                let mut chunk = Box::new([T::default(); 4096]);
+                chunk[index] = data;
+                self.blocks = Some(chunk);
+            }
+        }
     }
 }

--- a/crates/bones3_core/src/storage/data.rs
+++ b/crates/bones3_core/src/storage/data.rs
@@ -29,7 +29,7 @@ where
 {
     fn default() -> Self {
         Self {
-            blocks: Some(Box::new([T::default(); 4096])),
+            blocks: None,
         }
     }
 }

--- a/crates/bones3_remesh/src/mesh/block_model.rs
+++ b/crates/bones3_remesh/src/mesh/block_model.rs
@@ -120,6 +120,6 @@ pub trait BlockShape: BlockData {
     /// the shape builder as needed.
     fn write_shape(&self, shape_builder: &mut ShapeBuilder);
 
-    /// Gets the neighboring block faces that are occluded by this block shape.
-    fn get_occludes(&self) -> BlockOcclusion;
+    /// Checks if one tile is to occlude another tile. Returns True if face is occluded. 
+    fn check_occlude(&self, face: BlockOcclusion, other: Self) -> bool;
 }

--- a/crates/bones3_remesh/src/mesh/block_model.rs
+++ b/crates/bones3_remesh/src/mesh/block_model.rs
@@ -120,6 +120,7 @@ pub trait BlockShape: BlockData {
     /// the shape builder as needed.
     fn write_shape(&self, shape_builder: &mut ShapeBuilder);
 
-    /// Checks if one tile is to occlude another tile. Returns True if face is occluded. 
+    /// Checks if one tile is to occlude another tile. Returns True if face is
+    /// occluded.
     fn check_occlude(&self, face: BlockOcclusion, other: Self) -> bool;
 }

--- a/crates/bones3_remesh/src/mesh/builder.rs
+++ b/crates/bones3_remesh/src/mesh/builder.rs
@@ -28,9 +28,7 @@ where
         let data = get_block(block_pos);
 
         let check_occlusion = |occlusion: &mut BlockOcclusion, face: BlockOcclusion| {
-            if get_block(block_pos + face.into_offset())
-                .check_occlude(face, get_block(block_pos))
-            {
+            if get_block(block_pos + face.into_offset()).check_occlude(face, get_block(block_pos)) {
                 occlusion.insert(face);
             }
         };

--- a/crates/bones3_remesh/src/mesh/builder.rs
+++ b/crates/bones3_remesh/src/mesh/builder.rs
@@ -29,8 +29,7 @@ where
 
         let check_occlusion = |occlusion: &mut BlockOcclusion, face: BlockOcclusion| {
             if get_block(block_pos + face.into_offset())
-                .get_occludes()
-                .contains(face.opposite_face())
+                .check_occlude(face, get_block(block_pos))
             {
                 occlusion.insert(face);
             }

--- a/examples/mesh_generation.rs
+++ b/examples/mesh_generation.rs
@@ -49,8 +49,8 @@ impl BlockShape for BlockState {
     fn check_occlude(&self, face: BlockOcclusion, _other: Self) -> bool {
         match self {
             BlockState::Empty => false, // if this tile is empty, it will never block a face
-            BlockState::Solid(_) => true, /* solid blocks allways will allays block neighboring
-                                            * faces */
+            BlockState::Solid(_) => true, // solid blocks allways will allays block neighboring
+            // faces
             BlockState::HalfSlab(_) => BlockOcclusion::NEG_Y.contains(face), /* A halfslab only
                                                                               * blocks faces
                                                                               * below it. */

--- a/examples/mesh_generation.rs
+++ b/examples/mesh_generation.rs
@@ -42,13 +42,18 @@ impl BlockShape for BlockState {
             },
         }
     }
-    // This function cheks whenever two neighboring faces are blockin each other. This has the pourpose 
-    // of culling non-visible faces, wich is essential to performance
+
+    // This function cheks whenever two neighboring faces are blockin each other.
+    // This has the pourpose of culling non-visible faces, wich is essential to
+    // performance
     fn check_occlude(&self, face: BlockOcclusion, _other: Self) -> bool {
         match self {
             BlockState::Empty => false, // if this tile is empty, it will never block a face
-            BlockState::Solid(_) => true, // solid blocks allways will allays block neighboring faces
-            BlockState::HalfSlab(_) => BlockOcclusion::NEG_Y.contains(face) // A halfslab only blocks faces below it. 
+            BlockState::Solid(_) => true, /* solid blocks allways will allays block neighboring
+                                            * faces */
+            BlockState::HalfSlab(_) => BlockOcclusion::NEG_Y.contains(face), /* A halfslab only
+                                                                              * blocks faces
+                                                                              * below it. */
         }
     }
 }

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -15,26 +15,24 @@ fn main() {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-enum BlockState {
+pub enum BlockState {
     #[default]
     Empty,
-    HalfSlab(u16),
     Solid(u16),
+    Liquid(u16)
 }
 
 impl BlockShape for BlockState {
     fn write_shape(&self, shape_builder: &mut ShapeBuilder) {
         match self {
             BlockState::Empty => {},
-            BlockState::HalfSlab(material) => {
+            BlockState::Solid(material) => {
                 shape_builder.add_shape(
-                    CubeModelBuilder::new()
-                        .set_size(Vec3::new(1.0, 0.5, 1.0))
-                        .set_occlusion(shape_builder.get_occlusion()),
+                    CubeModelBuilder::new().set_occlusion(shape_builder.get_occlusion()),
                     *material,
                 );
             },
-            BlockState::Solid(material) => {
+            BlockState::Liquid(material) => {
                 shape_builder.add_shape(
                     CubeModelBuilder::new().set_occlusion(shape_builder.get_occlusion()),
                     *material,
@@ -42,18 +40,30 @@ impl BlockShape for BlockState {
             },
         }
     }
-    // This function cheks whenever two neighboring faces are blockin each other. This has the pourpose 
-    // of culling non-visible faces, wich is essential to performance
-    fn check_occlude(&self, face: BlockOcclusion, _other: Self) -> bool {
-        match self {
-            BlockState::Empty => false, // if this tile is empty, it will never block a face
-            BlockState::Solid(_) => true, // solid blocks allways will allays block neighboring faces
-            BlockState::HalfSlab(_) => BlockOcclusion::NEG_Y.contains(face) // A halfslab only blocks faces below it. 
+
+    // transparency is a bit harder to achive, but here is how:
+    fn check_occlude(&self, _: BlockOcclusion, other: Self) -> bool {
+        match self { 
+            BlockState::Empty => false,
+            BlockState::Solid(_) => {
+                match other {
+                    BlockState::Solid(_) => true, 
+                    BlockState::Empty => false,
+                    BlockState::Liquid(_) => true
+                }
+            },
+            BlockState::Liquid(_) => {
+                match other {
+                    BlockState::Solid(_) => false,
+                    BlockState::Empty => false,
+                    BlockState::Liquid(_) => true
+                }
+            },
         }
     }
 }
 
-fn init(
+pub fn init(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut chunk_materials: ResMut<ChunkMaterialList>,
     mut commands: VoxelCommands,
@@ -74,7 +84,7 @@ fn init(
             ..default()
         })
         .commands()
-        .insert_resource(AmbientLight {
+            .insert_resource(AmbientLight {
             color:      Color::WHITE,
             brightness: 2.5,
         });
@@ -83,6 +93,8 @@ fn init(
     let stone_index = chunk_materials.add_material(stone_handle);
     let grass_handle = materials.add(Color::DARK_GREEN.into());
     let grass_index = chunk_materials.add_material(grass_handle);
+    let water_handle = materials.add(Color::Rgba { red: 0.0, green: 0.0, blue: 0.8, alpha: 0.8 }.into());
+    let water_index = chunk_materials.add_material(water_handle);
 
     let mut world = commands.spawn_world(SpatialBundle::default());
 
@@ -101,10 +113,10 @@ fn init(
 
             if vert < shape.floor() {
                 storage.set_block(pos, BlockState::Solid(material_index));
-            } else if vert < (shape + 0.25).floor() {
-                storage.set_block(pos, BlockState::HalfSlab(material_index));
+            } else if vert +0.5 > shape.floor() && vert < 10.0{
+                storage.set_block(pos, BlockState::Liquid(water_index));
             } else {
-                storage.set_block(pos, BlockState::Empty);
+                storage.set_block(pos, BlockState::Empty)
             }
         }
 

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -19,7 +19,7 @@ pub enum BlockState {
     #[default]
     Empty,
     Solid(u16),
-    Liquid(u16)
+    Liquid(u16),
 }
 
 impl BlockShape for BlockState {
@@ -43,20 +43,20 @@ impl BlockShape for BlockState {
 
     // transparency is a bit harder to achive, but here is how:
     fn check_occlude(&self, _: BlockOcclusion, other: Self) -> bool {
-        match self { 
+        match self {
             BlockState::Empty => false,
             BlockState::Solid(_) => {
                 match other {
-                    BlockState::Solid(_) => true, 
+                    BlockState::Solid(_) => true,
                     BlockState::Empty => false,
-                    BlockState::Liquid(_) => true
+                    BlockState::Liquid(_) => true,
                 }
             },
             BlockState::Liquid(_) => {
                 match other {
                     BlockState::Solid(_) => false,
                     BlockState::Empty => false,
-                    BlockState::Liquid(_) => true
+                    BlockState::Liquid(_) => true,
                 }
             },
         }
@@ -84,7 +84,7 @@ pub fn init(
             ..default()
         })
         .commands()
-            .insert_resource(AmbientLight {
+        .insert_resource(AmbientLight {
             color:      Color::WHITE,
             brightness: 2.5,
         });
@@ -93,7 +93,15 @@ pub fn init(
     let stone_index = chunk_materials.add_material(stone_handle);
     let grass_handle = materials.add(Color::DARK_GREEN.into());
     let grass_index = chunk_materials.add_material(grass_handle);
-    let water_handle = materials.add(Color::Rgba { red: 0.0, green: 0.0, blue: 0.8, alpha: 0.8 }.into());
+    let water_handle = materials.add(
+        Color::Rgba {
+            red:   0.0,
+            green: 0.0,
+            blue:  0.8,
+            alpha: 0.8,
+        }
+        .into(),
+    );
     let water_index = chunk_materials.add_material(water_handle);
 
     let mut world = commands.spawn_world(SpatialBundle::default());
@@ -113,7 +121,7 @@ pub fn init(
 
             if vert < shape.floor() {
                 storage.set_block(pos, BlockState::Solid(material_index));
-            } else if vert +0.5 > shape.floor() && vert < 10.0{
+            } else if vert + 0.5 > shape.floor() && vert < 10.0 {
                 storage.set_block(pos, BlockState::Liquid(water_index));
             } else {
                 storage.set_block(pos, BlockState::Empty)


### PR DESCRIPTION
Change BlockShape trait to allow for transparent blocks, as in #7 and adds an example for transparent voxels and Fixes internal occlusion checks to properly handle these. This comes at the cost of breaking api changes.
`fn check_occlude(&self, face: BlockOcclusion, other: Self) -> bool;` is the new replacment for ` fn get_occludes(&self) -> BlockOcclusion;` in the BlockShape trait.